### PR TITLE
0.0.1 - Subscription cache

### DIFF
--- a/packages/structure/basecollection/CHANGELOG.md
+++ b/packages/structure/basecollection/CHANGELOG.md
@@ -1,0 +1,8 @@
+## 0.0.1 - Initial commit
+Contains the following features:
+
+* The main classes: One for the client and the other for the server only.
+* These classes uses aggregation instead of inheritance favoring integration
+  of other collection utils like aldeed:collections2, dburdles:collection-helpers, ...
+* Schema as Simple Schema.
+* Indexing set on Mongo.

--- a/packages/structure/basecollection/LICENSE.md
+++ b/packages/structure/basecollection/LICENSE.md
@@ -1,0 +1,1 @@
+MIT - See [SpaceDrop's license](https://github.com/spacedrop/spacedrop/blob/master/LICENSE.txt).

--- a/packages/structure/basecollection/README.md
+++ b/packages/structure/basecollection/README.md
@@ -1,0 +1,10 @@
+# Structure - BaseCollection
+## Introduction
+[SpaceDrop](http://spacedropcms.org/) provides the best of practices concerning
+Collection management: Subscription, Publishing rules, Argument checks, Indexing
+of Mongo Collection, ...
+
+## Usage
+```sh
+meteor add spacedrop:basecollection
+```

--- a/packages/structure/basecollection/basecollection.js
+++ b/packages/structure/basecollection/basecollection.js
@@ -1,0 +1,124 @@
+// Technical articles :
+// * http://joshowens.me/how-to-optimize-your-mongo-database-for-meteor-js/
+
+/** Base class for Collection. Takes car of default value and ensure indexes. */
+class BaseCollection {
+  /**
+   * C-tor
+   * @param Object literal with:
+   *  * name: The collection name.
+   *  * schame: A SimpleSchema on the Collection.
+   *  * subs: An object literal on the Collection.
+   */
+  constructor({ name, schema, subs }) {
+    // Assign arguments as class properties
+    let [ args, dummy ] = [...arguments];
+    for (let prop of Object.keys(args)) {
+      this[prop] = args[prop];
+    }
+    // Create a logger
+    this.logger = Logger.createLogger(`Collection ${this.name}`);
+    // Create a Meteor collection
+    this.collection = new Meteor.Collection(this.name);
+    this.logger.info('Created');
+    // Create Schema and attach it to the collection
+    this.schema = new SimpleSchema(schema);
+    this.collection.attachSchema(this.schema);
+    this.logger.info('Schema attached');
+    // Create subscription methods
+    for (let key of Object.keys(this.subs)) {
+      // Ensure immediate call
+      (subName => {
+        this.logger.info(`Subscrition method ${this.name}${subName} declared`);
+        // Create the method
+        let subscribeFct = function() {
+          let variables = [...arguments];
+          this.logger.info('Subscribing to', subName, 'with', variables);
+          let boundVars = [`${this.name}${subName}`].concat(variables);
+          return SD.Utils.globalSubs.subscribe.apply(SD.Utils.globalSubs, boundVars);
+        };
+        Object.defineProperty(this, `sub${subName}`, { value: subscribeFct });
+      })(key);
+    }
+  }
+}
+// Export class
+SD.Structure.BaseCollection = BaseCollection;
+
+// Server only
+if (Meteor.isServer) {
+  /** Server side base collection. Add defaults and indexes in Mongo */
+  class ServerBaseCollection extends BaseCollection {
+    /**
+     * C-tor.
+     * @param  {Object} sharedOptions Same options as thus for BaseCollection.
+     * @param  {Object} serverOptions Specific options for the defaults and the indexes.
+     */
+    constructor(sharedOptions, serverOptions) {
+      super(sharedOptions);
+      // Assign serverOptions as class properties
+      for (let prop of Object.keys(serverOptions)) {
+        this[prop] = serverOptions[prop];
+      }
+      // Create indexes if provided
+      if (this.indexes) { this._createIndexes(); }
+      // Create default data if provided
+      if (this.defaults) { this._createDefaults(); }
+      // Publish data for the subscriptions
+      if (this.subs) { this._createPublications(); }
+    }
+    _createIndexes() {
+      this.collection._ensureIndex(this.indexes);
+      this.logger.info('Indexes created');
+    }
+    _createDefaults() {
+      if (this.collection.find().count() !== 0) {
+        return this.logger.info('Defaults already filled');
+      }
+      // Add MongoID's
+      for (var d of this.defaults) {
+        d._id = new Meteor.Collection.ObjectID().valueOf();
+      }
+      // Batch insert default Documents
+      this.collection.rawCollection().insert(this.defaults, (err, res) => {
+        if (err) {
+          return this.logger.error(err);
+        }
+        this.logger.info('Defaults created');
+      });
+    }
+    _createPublications() {
+      for (let key of Object.keys(this.subs)) {
+        this.logger.info(`Publishing ${this.name}${key}`);
+        // Ensure immediate call
+        (subName => {
+          const publishFct = function() {
+            this.logger.debug('Received args', arguments);
+            this.logger.info(`Publishing ${subName} for user ${this.userId} with ${arguments.length} args`);
+            // Check arguments and build a potential mongo query selector
+            let query = {};
+            if (this.subs[subName].query) {
+              // Subscription is on a query
+              for (let varIdx in arguments) {
+                check(arguments[varIdx],
+                      this.schema.getDefinition(this.subs[subName].query[varIdx]).type);
+                query[this.subs[subName].query[varIdx]] = arguments[varIdx];
+              }
+            } else if (this.subs[subName].filter) {
+              // Subscription is on a filter
+              query = this.subs[subName].filter;
+            }
+            // Get query options
+            let options = this.subs[subName].options ? this.subs[subName].options : {};
+            // When a query parameter is used, consider the return a a single element
+            return this.collection.find(query, options);
+          }.bind(this);
+          Meteor.publish(`${this.name}${subName}`, publishFct);
+        })(key);
+      }
+      this.logger.info('Data published');
+    }
+  }
+  // Export class
+  SD.Structure.ServerBaseCollection = ServerBaseCollection;
+}

--- a/packages/structure/basecollection/package.js
+++ b/packages/structure/basecollection/package.js
@@ -1,0 +1,30 @@
+Package.describe({
+  name: 'spacedrop:basecollection',
+  version: '0.0.1',
+  summary: 'Structure basecollection class for SpaceDrop',
+  documentation: 'README.md',
+  git: 'https://github.com/spacedrop/spacedrop.git'
+});
+
+Package.onUse(function(api) {
+  // Meteor's API version
+  api.versionsFrom('1.2');
+  // Dependencies of this package
+  // Dependencies for server and client
+  const shared = [
+    'ecmascript',
+    'es5-shim',
+    'aldeed:collection2@2.5.0',
+    'dburles:collection-helpers@1.0.3',
+    'spacedrop:namespaces',
+    'pierreeric:logger',
+    'spacedrop:subscription-cache'
+  ];
+  api.use(shared);
+  api.imply(shared);
+  // Included files in this packages
+  // Files for server and client
+  api.addFiles([
+    'basecollection.js',
+  ]);
+});

--- a/packages/utils/subscription-cache/CHANGELOG.md
+++ b/packages/utils/subscription-cache/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 0.0.1 - Initial commit
+A simple subscription cache exposed in the SD.Utils namespaces.

--- a/packages/utils/subscription-cache/LICENSE.md
+++ b/packages/utils/subscription-cache/LICENSE.md
@@ -1,0 +1,1 @@
+MIT - See [SpaceDrop's license](https://github.com/spacedrop/spacedrop/blob/master/LICENSE.txt).

--- a/packages/utils/subscription-cache/README.md
+++ b/packages/utils/subscription-cache/README.md
@@ -1,0 +1,13 @@
+# Namespace
+## Introduction
+As default, [SpaceDrop](http://spacedropcms.org/) leverages [Arunoda's subscription
+caching](https://github.com/kadirahq/subs-manager). This package exposes the
+cache for the framework as well as for your applications.
+
+## Usage
+```sh
+meteor add spacedrop:subscription-cache
+```
+
+## API
+* SD.Utils.globalSubs: The subs-manager for [SpaceDrop](http://spacedropcms.org/).

--- a/packages/utils/subscription-cache/package.js
+++ b/packages/utils/subscription-cache/package.js
@@ -1,0 +1,28 @@
+Package.describe({
+  name: 'spacedrop:subscription-cache',
+  version: '0.0.1',
+  summary: 'Subscription cache for SpaceDrop',
+  documentation: 'README.md',
+  git: 'https://github.com/spacedrop/spacedrop.git'
+});
+
+Package.onUse(function(api) {
+  // Meteor's API version
+  api.versionsFrom('1.2');
+  // Dependencies of this package
+  // Dependencies for server and client
+  const shared = [
+    'meteorhacks:subs-manager@1.6.2',
+    'spacedrop:namespaces'
+  ];
+  api.use([
+    'pierreeric:logger'
+  ].concat(shared));
+  // Expose namespaces and subs-manager
+  api.imply(shared);
+  // Included files in this packages
+  // Files for server and client
+  api.addFiles([
+    'subscription-cache.js',
+  ]);
+});

--- a/packages/utils/subscription-cache/subscription-cache.js
+++ b/packages/utils/subscription-cache/subscription-cache.js
@@ -1,0 +1,14 @@
+// Create a subscription cache
+
+// Create a logger
+const log = Logger.createLogger('Subscription cache');
+
+// Subscription cache with a cache limit and an expiration
+SD.Utils.globalSubs = new SubsManager({
+  // Maximum number of cached subscriptions
+  cacheLimit: 10,
+  // Expiration in minutes
+  expireIn: 5
+});
+
+log.info('Declared');


### PR DESCRIPTION
Very simple subscription cache based on subs-manager.

Idea for enhancement:
- Set the cache with the current default but relies on Meteor.settings for separating value from development and production settings.
- Create a default `dev.json` and `prod.json` with more interesting values.
